### PR TITLE
change the location of the start command in package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ EXPOSE 3000
 
 
 #start app
+RUN npx browserslist@latest --update-db
 CMD ["npm","start"]
 
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "^4.3.5"
   },
   "scripts": {
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start --openssl-legacy-provider",
     "build": "react-scripts build",
     "build:staging": "env-cmd -f .env.staging react-scripts build",
     "build:demo": "env-cmd -f .env.demo react-scripts build",


### PR DESCRIPTION
change the location of the start command
after receive this error:
/usr/local/bin/node: bad option: --openssl-legacy-provider