### PR TITLE
[FEAT-647] Add design to injured_count_by_accident_year and accident_count_by_accident_year

### DIFF
--- a/src/components/molecules/GenericBarChart.tsx
+++ b/src/components/molecules/GenericBarChart.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { ResponsiveContainer, BarChart, LabelList, XAxis, Bar, Tooltip, Legend } from 'recharts';
 import { roseColor, honeyColor, yellowColor, blackColor, whiteColor } from 'style';
 import { Typography } from 'components/atoms';
+import { Box } from "@material-ui/core";
 import tinycolor from 'tinycolor2';
 
 const colors = [roseColor, honeyColor, yellowColor];
@@ -54,7 +55,6 @@ const CustomizedLabel = (props: CustomizedLabelProps) => {
 const BarChartContainer: FC<IBarChartBaseProps> = ({ data, textLabel, subtitle, children, isStacked }) => {
   return (
     <>
-      {!subtitle && <Typography.Body3>{textLabel}</Typography.Body3>}
       <ResponsiveContainer>
         <BarChart data={data} margin={{ bottom: 20 }}>
           <XAxis
@@ -66,7 +66,7 @@ const BarChartContainer: FC<IBarChartBaseProps> = ({ data, textLabel, subtitle, 
             style={{ fill: blackColor }}
           />
           <Tooltip />
-          {isStacked && <Legend verticalAlign="top" align="right" iconType="circle" height={35} />}
+          {isStacked && <Legend verticalAlign="bottom" align="right" iconType="circle" height={35} />}
           {children}
         </BarChart>
       </ResponsiveContainer>

--- a/src/components/molecules/card/AnyWayCard.tsx
+++ b/src/components/molecules/card/AnyWayCard.tsx
@@ -156,7 +156,8 @@ const AnyWayCard: FC<IProps> = ({
               <CardHeader
                 orgIconPath={organizationData?.path}
                 variant={variant.header}
-                text={subtitle ? `${title} ${subtitle}` : title}
+                title={title}
+                subtitle={subtitle}
                 road={roadNumber}
               />
             </Box>

--- a/src/components/molecules/card/CardHeader.tsx
+++ b/src/components/molecules/card/CardHeader.tsx
@@ -6,7 +6,6 @@ import LamasImage from 'assets/cbs.png';
 import AnywayImage from 'assets/anyway.png';
 import { Typography, Logo } from 'components/atoms';
 import { silverSmokeColor, opacity80percent } from 'style/';
-import { splitTextHeader } from 'utils/string.utils';
 
 const useStyles = makeStyles({
   wrapper: {
@@ -37,14 +36,14 @@ const useStyles = makeStyles({
 
 interface IProps {
   variant: HeaderVariant;
-  text: string | undefined;
+  title: string | undefined;
+  subtitle: string | undefined;
   road: number;
   orgIconPath?: string;
 }
-const CardHeader: FC<IProps> = ({ variant, text, road,orgIconPath }) => {
+const CardHeader: FC<IProps> = ({ variant, title, subtitle, road,orgIconPath }) => {
   const classes = useStyles();
   let headerContent = null;
-  const headerText = splitTextHeader(text);
   const roadNumberComp: JSX.Element | null = road ? <RoadNumberImage roadNumber={road} /> : null;
 
   switch (variant) {
@@ -56,10 +55,10 @@ const CardHeader: FC<IProps> = ({ variant, text, road,orgIconPath }) => {
           <Box display="flex" justifyContent="center" px={2} className={classes.textWrapper}>
             <Box display="flex" flexDirection="column">
               { variant === HeaderVariant.Centered &&
-                <>
-                <Typography.Body1>{headerText?.textLine1}</Typography.Body1>
-                <Typography.Body1>{headerText?.textLine2}</Typography.Body1>
-                </>
+                <Box textAlign="center">
+                  <Typography.Title2 bold>{title}</Typography.Title2>
+                  <Typography.Body2>{subtitle}</Typography.Body2>
+                </Box>
               }
             </Box>
           </Box>
@@ -73,7 +72,7 @@ const CardHeader: FC<IProps> = ({ variant, text, road,orgIconPath }) => {
             {roadNumberComp}
           </Box>
           <Box textAlign="center" px={2} className={classes.label}>
-            <Typography.Body1>{text}</Typography.Body1>
+            <Typography.Body1>{subtitle ? `${title} ${subtitle}` : title}</Typography.Body1>
           </Box>
         </Box>
       );

--- a/src/components/molecules/widgets/CountByYearBarWidget.tsx
+++ b/src/components/molecules/widgets/CountByYearBarWidget.tsx
@@ -11,7 +11,9 @@ interface IProps {
 const CountByYearBarWidget: FC<IProps> = ({ data, editorBarOptions }) => {
   const { text } = data;
   const multiBarSeries = createBarWidget(data, editorBarOptions)
-  return <MultiBarChart isStacked={true} isPercentage={false} data={multiBarSeries} textLabel={text.title}
+  return <MultiBarChart isStacked={true} isPercentage={false} data={multiBarSeries}
+                        textLabel={text.title}
+                        subtitle={text.subtitle}
                         editorBarOptions={editorBarOptions} />;
 };
 export default CountByYearBarWidget;

--- a/src/components/molecules/widgets/CountInjuredByYearBarWidget.tsx
+++ b/src/components/molecules/widgets/CountInjuredByYearBarWidget.tsx
@@ -12,7 +12,9 @@ interface IProps {
 const CountInjuredByYearBarWidget: FC<IProps> = ({ data, editorBarOptions }) => {
   const { text } = data;
   const multiBarSeries = createBarWidget(data, editorBarOptions);
-  return <MultiBarChart isStacked={true} isPercentage={false} data={multiBarSeries} textLabel={text.title}
+  return <MultiBarChart isStacked={true} isPercentage={false} data={multiBarSeries}
+                        textLabel={text.title}
+                        subtitle={text.subtitle}
                         editorBarOptions={editorBarOptions} />;
 };
 export default CountInjuredByYearBarWidget;

--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,8 @@ svg {
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+/* Add left padding for legend icons (for hebrew compatibility) */
+.recharts-legend-item-text {
+  padding-right: 5px;
+}

--- a/src/models/WidgetData.ts
+++ b/src/models/WidgetData.ts
@@ -185,6 +185,7 @@ export interface IWidgetMultiBarData extends IWidgetDataBase {
   items: MultiSeriesDataItems[];
   text: {
     title?: string;
+    subtitle?: string;
     labels_map: LabelsMap;
   };
 }

--- a/src/services/widgets.style.service.ts
+++ b/src/services/widgets.style.service.ts
@@ -37,8 +37,8 @@ const widgetVariants: { [index: string]: CardVariant } = {
     footer: FooterVariant.LogoWithRange,
   },
   [WidgetName.accident_count_by_accident_type]: { header: HeaderVariant.Centered, footer: FooterVariant.Logo },
-  [WidgetName.accident_count_by_accident_year]: { header: HeaderVariant.Logo, footer: FooterVariant.None },
-  [WidgetName.injured_count_by_accident_year]: { header: HeaderVariant.Logo, footer: FooterVariant.None },
+  [WidgetName.accident_count_by_accident_year]: { header: HeaderVariant.Centered, footer: FooterVariant.LogoWithRange },
+  [WidgetName.injured_count_by_accident_year]: { header: HeaderVariant.Centered, footer: FooterVariant.LogoWithRange },
   [WidgetName.accident_count_by_day_night]: { header: HeaderVariant.Centered, footer: FooterVariant.LogoWithRange },
   [WidgetName.head_on_collisions_comparison]: { header: HeaderVariant.Label, footer: FooterVariant.LogoWithRange },
   [WidgetName.head_on_collisions_comparison_percentage]: {


### PR DESCRIPTION
This changes were made:
- use "title": מספר נפגעים לפי שנה, לפי חומרה “subtitle": צומת דימונה - צומת בית אשל
please don't concatenate them but keep etch one in a different row

- legend: main change is in the legend location below or above the graph. preferably below.

- Add a space in the legend between the point and the text(not madatory)

from https://github.com/data-for-change/anyway-newsflash-infographics/issues/647