### PR TITLE
[BUG-1171] Fix bug in newsId fetch when different language url

### DIFF
--- a/src/utils/url.utils.ts
+++ b/src/utils/url.utils.ts
@@ -1,6 +1,6 @@
 export const getNewsIdFromUrl = () => {
   const pathname = window.location.pathname;
-  const [, , newsId] = pathname.split('/');
+  const newsId = pathname.split('/')[-1];
 
   return newsId ? { newsFlashId: +newsId } : { pageNumber: 1 };
 };


### PR DESCRIPTION
@SejoB Please note that your change here broke the case when language is not hebrew, because in that case the url is for example .../en/newsflash/239172 and the code change you did there didnt work in that case.